### PR TITLE
Don’t require both caFile and caPath when setting TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ API|Parameters|Description
 
 ### TLS Configuration
 
-- Set TLS certification file: `func setTLS(caFile: String, caPath: String, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws`
+- Set TLS certification file: `func setTLS(caFile: String?, caPath: String?, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws`
 
 - Set TLS verification method: `func setTLS(verify: SSLVerify = .PEER, version: String? = nil, ciphers: String? = nil) throws`
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -228,7 +228,7 @@ API|参数|说明
 
 ### TLS 配置
 
-- 设置 TLS 证书： `func setTLS(caFile: String, caPath: String, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws`
+- 设置 TLS 证书： `func setTLS(caFile: String?, caPath: String?, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws`
 
 - 设置 TLS 验证方法： `func setTLS(verify: SSLVerify = .PEER, version: String? = nil, ciphers: String? = nil) throws`
 

--- a/Sources/PerfectMosquitto/PerfectMosquitto.swift
+++ b/Sources/PerfectMosquitto/PerfectMosquitto.swift
@@ -245,14 +245,14 @@ public class Mosquitto {
   /// private key. If your private key is encrypted, provide a password .
   ///
   /// - parameters:
-  ///   - caFile: String, path to a file containing the PEM encoded trusted CA certificate files. Either cafile or capath must not be nil.
-  ///   - caPath: String, path to a directory containing the PEM encoded trusted CA certificate files. See mosquitto.conf for more details on configuring this directory. Either cafile or capath must not be nil.
+  ///   - caFile: String?, path to a file containing the PEM encoded trusted CA certificate files. Either cafile or capath must not be nil.
+  ///   - caPath: String?, path to a directory containing the PEM encoded trusted CA certificate files. See mosquitto.conf for more details on configuring this directory. Either cafile or capath must not be nil.
   ///   - certFile: String?, path to a file containing the PEM encoded certificate file for this client. If nil, keyfile must be nil, too
   ///   - keyfile: String?, path to a file containing the PEM encoded private key for this client. if nil, the certfile must be nil, too.
   ///   - keyPass: String?, if keyfile is encrypted, set this password to decryption.
   /// - throws:
   ///   Exception
-  public func setTLS(caFile: String, caPath: String, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws {
+  public func setTLS(caFile: String?, caPath: String?, certFile: String? = nil, keyFile: String? = nil, keyPass: String? = nil) throws {
     var r = Int32(0)
     if let kp = keyPass {
       self.tlsPassword = kp


### PR DESCRIPTION
I encountered an issue where I only wanted to use the `caFile` option so I set an empty string to `caPath`:

```swift
try mosquitto.setTLS(caFile: "/usr/local/etc/openssl/cert.pem", caPath: "")
```

 This caused Mosquitto to fail with:

```
Error: Unable to load CA certificates, check cafile "/usr/local/etc/openssl/cert.pem" and capath ""
```

I identified the issue by looking in Mosquitto’s source here: https://github.com/eclipse/mosquitto/blob/995f90dbafa82c7fd3d24f7174d094f11c2d6c85/lib/net_mosq.c#L629-L647

This change makes both `caFile` and `caPath` optional, as indicated it should be by the method documentation.

```swift
try mosquitto.setTLS(caFile: "/usr/local/etc/openssl/cert.pem", caPath: nil)
```

Thanks for the great library!