### PR TITLE
Update package config from `mosquitto` to `libmosquitto`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
   targets: [
     .systemLibrary(name: "cmosquitto",
-      pkgConfig: "mosquitto",
+      pkgConfig: "libmosquitto",
       providers:[
         .brew(["mosquitto"]),
         .apt(["libmosquitto-dev"])

--- a/README.md
+++ b/README.md
@@ -55,27 +55,6 @@ This project depends on mosquitto library. To install on mac OS, try command `br
 $ brew install mosquitto
 ```
 
-### PC File
-
-A package configuration file is needed, for example, `/usr/local/lib/pkgconfig/mosquitto.pc` as below:
-
-```
-Name: mosquitto
-Description: Mosquitto Client Library
-Version: 1.4.11
-Requires:
-Libs: -L/usr/local/lib -lmosquitto
-Cflags: -I/usr/local/include
-
-```
-
-
-Please also export an environmental variable called `$PKG_CONFIG_PATH`:
-
-```
-$ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
-```
-
 ## Linux Notes
 
 This project depends on Ubuntu 16.04 library `libmosquitto-dev`:

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -59,26 +59,6 @@
 $ brew install mosquitto
 ```
 
-### PC 配置文件
-
-本项目同时需要手工编辑配置文件`/usr/local/lib/pkgconfig/mosquitto.pc`，内容如下：
-
-```
-Name: mosquitto
-Description: Mosquitto Client Library
-Version: 1.4.11
-Requires:
-Libs: -L/usr/local/lib -lmosquitto
-Cflags: -I/usr/local/include
-
-```
-
-并且请确定当前终端环境中包括变量 `$PKG_CONFIG_PATH`:
-
-```
-$ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
-```
-
 ## Linux 编译说明
 
 本项目需要 Ubuntu 16.04 静态函数库 `libmosquitto-dev`:


### PR DESCRIPTION
This fixes https://github.com/PerfectlySoft/Perfect-Mosquitto/issues/4.

mosquitto provides a default package configuration named `libmosquitto.pc`: https://github.com/eclipse/mosquitto/pull/213

It also looks like we no longer need to export the package config path:
```
$ export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
```

SPM already searches for this path: https://github.com/apple/swift-package-manager/blob/d58d857c5049a6e0e27896fe9a21f00e42b16527/Sources/SPMUtility/PkgConfig.swift#L54-L57